### PR TITLE
Patch/fix warning values

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -8,6 +8,7 @@ import { NormalizedOutputOptions } from "rollup";
 // eslint-disable-next-line no-control-regex
 const ansiRegex = /[\u001b\u009b][[()#;?]*(?:\d{1,4}(?:;\d{0,4})*)?[\dA-ORZcf-nqry=><]/g;
 
+// TODO: add test to check if the output will use the default warning values when it's not passed, or an empty object was passed
 describe("Rollup plugin summary", () => {
   const options: Partial<NormalizedOutputOptions> = { dir: "temp/esm" };
   const log = jest.fn();

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,17 +12,15 @@ import {
 import { OutputChunk, Plugin } from "rollup";
 
 /** Prints out a summary of the rollup build */
-export function summary(
-  opts: SummaryOptions = {
-    warnLow: 5e3,
-    warnHigh: 1e4,
-    totalLow: 2e5,
-    totalHigh: 3e5,
-    showBrotliSize: false,
-    showGzippedSize: false,
-    showMinifiedSize: false,
-  },
-): Plugin {
+export function summary({
+  warnLow = 5e3,
+  warnHigh = 1e4,
+  totalLow = 2e5,
+  totalHigh = 3e5,
+  showBrotliSize = false,
+  showGzippedSize = false,
+  showMinifiedSize = false,
+}: SummaryOptions = {}): Plugin {
   const info = new Map<string, SummaryChunkInfo[]>();
 
   return {
@@ -47,7 +45,8 @@ export function summary(
           const chunk = bundle[fileName];
           // TODO: Investigate this
           const code = (chunk as OutputChunk).code;
-          const warn: [number, number] = [opts.warnLow || 0, opts.warnHigh || 0];
+          const warn: [number, number] = [warnLow || 0, warnHigh || 0];
+          const totalWarn: [number, number] = [totalLow || 0, totalHigh || 0];
           /** @type {SummaryChunkInfo} */
           const chunkInfo: SummaryChunkInfo = { fileName, size: defaultDescriptor() };
           chunkInfo.size.value = Buffer.byteLength(code);
@@ -55,9 +54,9 @@ export function summary(
           chunkInfo.size.coloredValue = reportWarning(chunkInfo.size, ...warn);
           totals.size.value += chunkInfo.size.value;
           totals.size.displayValue = getFileSize(totals.size.value);
-          totals.size.coloredValue = reportWarning(totals.size, ...warn);
+          totals.size.coloredValue = reportWarning(totals.size, ...totalWarn);
 
-          if (opts.showMinifiedSize) {
+          if (showMinifiedSize) {
             if (!chunkInfo.minified) {
               chunkInfo.minified = defaultDescriptor();
             }
@@ -69,10 +68,10 @@ export function summary(
             chunkInfo.minified.coloredValue = reportWarning(chunkInfo.minified, ...warn);
             totals.minified.value += chunkInfo.minified.value;
             totals.minified.displayValue = getFileSize(totals.minified.value);
-            totals.minified.coloredValue = reportWarning(totals.minified, ...warn);
+            totals.minified.coloredValue = reportWarning(totals.minified, ...totalWarn);
           }
 
-          if (opts.showGzippedSize) {
+          if (showGzippedSize) {
             if (!chunkInfo.gzipped) {
               chunkInfo.gzipped = defaultDescriptor();
             }
@@ -84,10 +83,10 @@ export function summary(
             chunkInfo.gzipped.coloredValue = reportWarning(chunkInfo.gzipped, ...warn);
             totals.gzipped.value += chunkInfo.gzipped.value;
             totals.gzipped.displayValue = getFileSize(totals.gzipped.value);
-            totals.gzipped.coloredValue = reportWarning(totals.gzipped, ...warn);
+            totals.gzipped.coloredValue = reportWarning(totals.gzipped, ...totalWarn);
           }
 
-          if (opts.showBrotliSize) {
+          if (showBrotliSize) {
             if (!chunkInfo.brotli) {
               chunkInfo.brotli = defaultDescriptor();
             }
@@ -99,7 +98,7 @@ export function summary(
             chunkInfo.brotli.coloredValue = reportWarning(chunkInfo.brotli, ...warn);
             totals.brotli.value += chunkInfo.brotli.value;
             totals.brotli.displayValue = getFileSize(totals.brotli.value);
-            totals.brotli.coloredValue = reportWarning(totals.brotli, ...warn);
+            totals.brotli.coloredValue = reportWarning(totals.brotli, ...totalWarn);
           }
           info.get(identifier)!.push(chunkInfo);
         }
@@ -110,9 +109,9 @@ export function summary(
       info.forEach((output, dir) => {
         /** @type {string[]} */
         const headers = ["File name", "Size"];
-        opts.showMinifiedSize && headers.push("Minified");
-        opts.showGzippedSize && headers.push("Gzipped");
-        opts.showBrotliSize && headers.push("Brotli");
+        showMinifiedSize && headers.push("Minified");
+        showGzippedSize && headers.push("Gzipped");
+        showBrotliSize && headers.push("Brotli");
         const table = new Table({
           head: headers,
           chars: { mid: "", "left-mid": "", "mid-mid": "", "right-mid": "" },
@@ -121,9 +120,9 @@ export function summary(
 
         const printable = output.map(file => {
           const output = [file.fileName, file.size.coloredValue];
-          opts.showMinifiedSize && output.push(file.minified!.coloredValue);
-          opts.showGzippedSize && output.push(file.gzipped!.coloredValue);
-          opts.showBrotliSize && output.push(file.brotli!.coloredValue);
+          showMinifiedSize && output.push(file.minified!.coloredValue);
+          showGzippedSize && output.push(file.gzipped!.coloredValue);
+          showBrotliSize && output.push(file.brotli!.coloredValue);
           return output;
         });
         const totalsRow: string[] = printable.pop()!;
@@ -132,9 +131,9 @@ export function summary(
           headers,
           ...output.map(file => {
             const output = [file.fileName, file.size.displayValue];
-            opts.showMinifiedSize && output.push(file.minified!.displayValue);
-            opts.showGzippedSize && output.push(file.gzipped!.displayValue);
-            opts.showBrotliSize && output.push(file.brotli!.displayValue);
+            showMinifiedSize && output.push(file.minified!.displayValue);
+            showGzippedSize && output.push(file.gzipped!.displayValue);
+            showBrotliSize && output.push(file.brotli!.displayValue);
             return output;
           }),
         ]);


### PR DESCRIPTION
## Problem
fixes a bug causing the warning values to be incorrectly calculated

a bug was causing an issue where if you pass an object to the plugin without specifying the warning
values, it will causing the warnings to be matched against 0 rendering all values in red