### PR TITLE
fix: fix the rollup build issue causing all dependencies to be bundled

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,9 +8,7 @@ import pkg from "./package.json";
 
 const esModules = ["gzip-size"];
 /** @type {string[]} */
-const external = Object.keys(pkg.dependencies).filter(
-  ext => ext === esModules.includes("gzip-size"),
-);
+const external = Object.keys(pkg.dependencies).filter(ext => !esModules.includes(ext));
 
 export default defineConfig({
   input: "src/index.ts",


### PR DESCRIPTION
fix the rollup build issue causing all dependencies to be bundled

a bug was causing all dependencies to be bundled in the final build which isn't ideal. this patch
fixes the issue which only bundles esmodules that cannot be used as external such as gzip-size. this
drastically improves the bundle size and maintainabilty