### PR TITLE
ci: update actions to v4

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,14 +8,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: "lts/*"
+          check-latest: false
       - run: npm ci
       - run: npm run build:docs
-      - uses: crazy-max/ghaction-github-pages@v1
+      - uses: crazy-max/ghaction-github-pages@v4
         with:
           build_dir: dist
+          target_branch: gh-pages
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,11 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: "lts/*"
+          check-latest: false
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build
@@ -27,6 +28,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - uses: codecov/codecov-action@v1.0.13
+      - uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,12 +13,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 20.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Installing dependencies

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,9 +1,9 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-eslint --fix . &&
+npx eslint --fix . &&
 npm run lint &&
 echo "✅ eslint finished successfully" &&
-prettier --write --ignore-unknown . &&
-prettier --check . &&
+npx prettier --write --ignore-unknown . &&
+npx prettier --check . &&
 echo "✅ Prettier finished successfully"


### PR DESCRIPTION
* Update actions to latest versions
* Fix pre-commit hook to not rely on globally installed dependencies
* Release a new version to allow usage with rollup@4