### PR TITLE
fix: Reusing an instance of a plugin will result in duplicate output of the summary

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -146,6 +146,7 @@ export function summary({
         console.log("Build summary for", color.cyan(dir));
         console.log(table.toString());
       });
+      info.clear();
     },
   };
 }


### PR DESCRIPTION
Fixed #73 